### PR TITLE
Add quickfixes to update reverse-sandbox scripts for python3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ TAGS
 *.log
 *.bin
 core
+.DS_STORE

--- a/reverse-sandbox/filters.py
+++ b/reverse-sandbox/filters.py
@@ -6,7 +6,7 @@ def read_filters():
     with open('filters.json') as data:
         temp = json.load(data)
 
-        for key, value in temp.iteritems():
+        for key, value in temp.items():
             filters[int(str(key), 16)] = value
 
     return filters

--- a/reverse-sandbox/operation_node.py
+++ b/reverse-sandbox/operation_node.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 import sys
 import struct
@@ -384,7 +384,7 @@ class OperationNode():
             self.non_terminal.convert_filter(convert_fn, f, regex_list, ios10_release, keep_builtin_filters, global_vars)
 
     def str_debug(self):
-        ret = "(%02x) " % (self.offset)
+        ret = "(%02x) " % (int)(self.offset)
         if self.is_terminal():
             ret += "terminal: "
             ret += str(self.terminal)
@@ -419,7 +419,7 @@ class OperationNode():
         return self.raw == other.raw
 
     def __hash__(self):
-        return self.offset
+        return (int)(self.offset)
 
 
 # Operation nodes processed so far.
@@ -589,9 +589,9 @@ def print_operation_node_graph(g):
         return
     message = ""
     for node_iter in g.keys():
-        message += "0x%x (%s) (%s) (decision: %s): [ " % (node_iter.offset, str(node_iter), g[node_iter]["type"], g[node_iter]["decision"])
+        message += "0x%x (%s) (%s) (decision: %s): [ " % ((int)(node_iter.offset), str(node_iter), g[node_iter]["type"], g[node_iter]["decision"])
         for edge in g[node_iter]["list"]:
-            message += "0x%x (%s) " % (edge.offset, str(edge))
+            message += "0x%x (%s) " % ((int)(edge.offset), str(edge))
         message += "]\n"
     logger.debug(message)
 
@@ -1675,7 +1675,7 @@ def reduce_operation_node_graph(g):
             c_idx += 1
             if c_idx >= l:
                 break
-            rn = rg.get_vertice_by_value(g.keys()[c_idx])
+            rn = rg.get_vertice_by_value(list(g.keys())[c_idx])
             if not re.search("entitlement-value", str(rn)):
                 break
             prevs_rv = rg.get_prev_vertices(rv)
@@ -1715,7 +1715,7 @@ def main():
 
     # Extract node for 'default' operation (index 0).
     default_node = find_operation_node_by_offset(operation_nodes, sb_ops_offsets[0])
-    print "(%s default)" % (default_node.terminal)
+    print("(%s default)" % (default_node.terminal))
 
     # For each operation expand operation node.
     #for idx in range(1, len(sb_ops_offsets)):
@@ -1736,7 +1736,7 @@ def main():
         else:
             if node.terminal:
                 if node.terminal.type != default_node.terminal.type:
-                    print "(%s %s)" % (node.terminal, operation)
+                    print("(%s %s)" % (node.terminal, operation))
 
 
 if __name__ == "__main__":

--- a/reverse-sandbox/reverse_sandbox.py
+++ b/reverse-sandbox/reverse_sandbox.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 iOS/OS X sandbox decompiler
@@ -154,7 +154,7 @@ def display_sandbox_profiles(f, re_table_offset, num_sb_ops, ios10_release):
         boundary = struct.unpack("<H", f.read(2))[0]
         name = extract_string_from_offset(f, name_offset)
 
-        print name
+        print(name)
 
     logger.info("Found %d sandbox profiles." % num_profiles)
 
@@ -196,7 +196,7 @@ def main():
 
     if args.filename is None:
         parser.print_usage()
-        print "no sandbox profile/bundle file to reverse"
+        print("no sandbox profile/bundle file to reverse")
         sys.exit(1)
 
     # Read sandbox operations.
@@ -209,7 +209,7 @@ def main():
         for op in args.operation:
             if op not in sb_ops:
                 parser.print_usage()
-                print "unavailable operation: {}".format(op)
+                print("unavailable operation: {}".format(op))
                 sys.exit(1)
             ops_to_reverse.append(op)
 
@@ -247,7 +247,7 @@ def main():
         if header == 0x8000:
             display_sandbox_profiles(f, re_table_offset, num_sb_ops, is_ios_more_than_10_release(args.release))
         else:
-            print "cannot print sandbox profiles list; filename {} is not a sandbox bundle".format(args.filename)
+            print("cannot print sandbox profiles list; filename {} is not a sandbox bundle".format(args.filename))
         sys.exit(0)
 
     global_vars = None
@@ -279,7 +279,7 @@ def main():
                 break
         start = f.tell()
         end = re_table_offset * 8
-        num_operation_nodes = (end - start) / 8
+        num_operation_nodes = (end - start) // 8
         logger.info("number of operation nodes: %u" % num_operation_nodes)
 
         operation_nodes = create_operation_nodes(f, regex_list, num_operation_nodes, is_ios_more_than_10_release(args.release), args.keep_builtin_filters, global_vars)

--- a/reverse-sandbox/reverse_string.py
+++ b/reverse-sandbox/reverse_string.py
@@ -349,7 +349,7 @@ def main():
     ss = SandboxString()
     my_global_vars = ["FRONT_USER_HOME", "HOME", "PROCESS_TEMP_DIR"]
     l = ss.parse_byte_string(s[4:], my_global_vars)
-    print list(set(l))
+    print(list(set(l)))
 
 
 if __name__ == "__main__":

--- a/reverse-sandbox/sandbox_regex.py
+++ b/reverse-sandbox/sandbox_regex.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import logging
 import logging.config
@@ -491,7 +491,7 @@ def main():
             logger.info("total_re_length: 0x%x", re_length)
             re_debug_str = "re: [", ", ".join([hex(i) for i in re]), "]"
             logger.info(re_debug_str)
-            print parse_regex(re)
+            print(parse_regex(re))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes errors that appear when trying to run scripts using python3.

In order for the scripts to work inside iExtractor, the iExtractor `scripts/sandblaster_reverse_profiles` script must be updated to call `reverse_sandbox.py` using python3.