### PR TITLE
Add dependency graph functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ TAGS
 *.log
 *.bin
 core
+.DS_STORE

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,30 @@
+BSD 3-Clause License
+
+Copyright (c) 2016, North Carolina State University and University POLITEHNICA
+of Bucharest.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ The reverser (in the `reverse-sandbox/` folder) runs on any Python running platf
 
 SandBlaster may be installed and run standalone, though we recommend installing and running it from within [iExtractor](https://github.com/malus-security/iExtractor). Check the [iExtractor documentation](https://github.com/malus-security/iExtractor/blob/master/README.md) for information.
 
+iExtractor is open source software released under the 3-clause BSD license.
+
 ## Installation
 
 SandBlaster requires Python for the reverser (in `reverse-sandbox/`), Bash for helper scripts (in `helpers/`) and tools from the [sandbox_toolkit](https://github.com/sektioneins/sandbox_toolkit) (in `tools/`).

--- a/reverse-sandbox/filters.py
+++ b/reverse-sandbox/filters.py
@@ -1,9 +1,10 @@
+from os import path
 import json
 
 def read_filters():
     temp = {}
     filters = {}
-    with open('filters.json') as data:
+    with open(path.join(path.dirname(__file__), "filters.json")) as data:
         temp = json.load(data)
 
         for key, value in temp.items():

--- a/reverse-sandbox/filters.py
+++ b/reverse-sandbox/filters.py
@@ -6,7 +6,7 @@ def read_filters():
     with open('filters.json') as data:
         temp = json.load(data)
 
-        for key, value in temp.iteritems():
+        for key, value in temp.items():
             filters[int(str(key), 16)] = value
 
     return filters

--- a/reverse-sandbox/operation_node.py
+++ b/reverse-sandbox/operation_node.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 import sys
 import struct
@@ -384,7 +384,7 @@ class OperationNode():
             self.non_terminal.convert_filter(convert_fn, f, regex_list, ios10_release, keep_builtin_filters, global_vars)
 
     def str_debug(self):
-        ret = "(%02x) " % (self.offset)
+        ret = "(%02x) " % (int)(self.offset)
         if self.is_terminal():
             ret += "terminal: "
             ret += str(self.terminal)
@@ -419,7 +419,7 @@ class OperationNode():
         return self.raw == other.raw
 
     def __hash__(self):
-        return self.offset
+        return (int)(self.offset)
 
 
 # Operation nodes processed so far.
@@ -589,9 +589,9 @@ def print_operation_node_graph(g):
         return
     message = ""
     for node_iter in g.keys():
-        message += "0x%x (%s) (%s) (decision: %s): [ " % (node_iter.offset, str(node_iter), g[node_iter]["type"], g[node_iter]["decision"])
+        message += "0x%x (%s) (%s) (decision: %s): [ " % ((int)(node_iter.offset), str(node_iter), g[node_iter]["type"], g[node_iter]["decision"])
         for edge in g[node_iter]["list"]:
-            message += "0x%x (%s) " % (edge.offset, str(edge))
+            message += "0x%x (%s) " % ((int)(edge.offset), str(edge))
         message += "]\n"
     logger.debug(message)
 
@@ -1675,7 +1675,7 @@ def reduce_operation_node_graph(g):
             c_idx += 1
             if c_idx >= l:
                 break
-            rn = rg.get_vertice_by_value(g.keys()[c_idx])
+            rn = rg.get_vertice_by_value(list(g.keys())[c_idx])
             if not re.search("entitlement-value", str(rn)):
                 break
             prevs_rv = rg.get_prev_vertices(rv)
@@ -1715,7 +1715,7 @@ def main():
 
     # Extract node for 'default' operation (index 0).
     default_node = find_operation_node_by_offset(operation_nodes, sb_ops_offsets[0])
-    print "(%s default)" % (default_node.terminal)
+    print("(%s default)" % (default_node.terminal))
 
     # For each operation expand operation node.
     #for idx in range(1, len(sb_ops_offsets)):
@@ -1736,7 +1736,7 @@ def main():
         else:
             if node.terminal:
                 if node.terminal.type != default_node.terminal.type:
-                    print "(%s %s)" % (node.terminal, operation)
+                    print("(%s %s)" % (node.terminal, operation))
 
 
 if __name__ == "__main__":

--- a/reverse-sandbox/regex_parser.py
+++ b/reverse-sandbox/regex_parser.py
@@ -1,6 +1,7 @@
+from os import path
 import logging
 
-logging.config.fileConfig("logger.config")
+logging.config.fileConfig(path.join(path.dirname(__file__), "logger.config"))
 logger = logging.getLogger(__name__)
 
 def parse_character(re, i, regex_list):

--- a/reverse-sandbox/reverse_sandbox.py
+++ b/reverse-sandbox/reverse_sandbox.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 iOS/OS X sandbox decompiler
@@ -154,7 +154,7 @@ def display_sandbox_profiles(f, re_table_offset, num_sb_ops, ios10_release):
         boundary = struct.unpack("<H", f.read(2))[0]
         name = extract_string_from_offset(f, name_offset)
 
-        print name
+        print(name)
 
     logger.info("Found %d sandbox profiles." % num_profiles)
 
@@ -196,7 +196,7 @@ def main():
 
     if args.filename is None:
         parser.print_usage()
-        print "no sandbox profile/bundle file to reverse"
+        print("no sandbox profile/bundle file to reverse")
         sys.exit(1)
 
     # Read sandbox operations.
@@ -209,7 +209,7 @@ def main():
         for op in args.operation:
             if op not in sb_ops:
                 parser.print_usage()
-                print "unavailable operation: {}".format(op)
+                print("unavailable operation: {}".format(op))
                 sys.exit(1)
             ops_to_reverse.append(op)
 
@@ -247,7 +247,7 @@ def main():
         if header == 0x8000:
             display_sandbox_profiles(f, re_table_offset, num_sb_ops, is_ios_more_than_10_release(args.release))
         else:
-            print "cannot print sandbox profiles list; filename {} is not a sandbox bundle".format(args.filename)
+            print("cannot print sandbox profiles list; filename {} is not a sandbox bundle".format(args.filename))
         sys.exit(0)
 
     global_vars = None
@@ -279,7 +279,7 @@ def main():
                 break
         start = f.tell()
         end = re_table_offset * 8
-        num_operation_nodes = (end - start) / 8
+        num_operation_nodes = (end - start) // 8
         logger.info("number of operation nodes: %u" % num_operation_nodes)
 
         operation_nodes = create_operation_nodes(f, regex_list, num_operation_nodes, is_ios_more_than_10_release(args.release), args.keep_builtin_filters, global_vars)

--- a/reverse-sandbox/reverse_string.py
+++ b/reverse-sandbox/reverse_string.py
@@ -349,7 +349,7 @@ def main():
     ss = SandboxString()
     my_global_vars = ["FRONT_USER_HOME", "HOME", "PROCESS_TEMP_DIR"]
     l = ss.parse_byte_string(s[4:], my_global_vars)
-    print list(set(l))
+    print(list(set(l)))
 
 
 if __name__ == "__main__":

--- a/reverse-sandbox/reverse_string.py
+++ b/reverse-sandbox/reverse_string.py
@@ -1,10 +1,11 @@
 import sys
+from os import path
 import struct
 import logging
 import time
 
 
-logging.config.fileConfig("logger.config")
+logging.config.fileConfig(path.join(path.dirname(__file__), "logger.config"))
 logger = logging.getLogger(__name__)
 
 

--- a/reverse-sandbox/sandbox_filter.py
+++ b/reverse-sandbox/sandbox_filter.py
@@ -2,15 +2,15 @@
 
 import struct
 import re
+from os import path
 import logging
 import logging.config
-import reverse_sandbox
 import reverse_string
 
 from filters import Filters
 
 
-logging.config.fileConfig("logger.config")
+logging.config.fileConfig(path.join(path.dirname(__file__), "logger.config"))
 logger = logging.getLogger(__name__)
 
 ios10_release = False
@@ -34,7 +34,7 @@ def get_filter_arg_string_by_offset(f, offset):
         logger.info("actual string is " + actual_string)
         return myss
     type = struct.unpack("<B", f.read(1))[0]
-    return '"%s"' % f.read(len)
+    return '"%s"' % f.read(len).decode('ascii')
 
 
 def get_filter_arg_string_by_offset_with_type(f, offset):
@@ -73,14 +73,14 @@ def get_filter_arg_string_by_offset_with_type(f, offset):
     actual_string = f.read(len)
     if actual_string == "/private/var/tmp/launchd/sock" and keep_builtin_filters == False:
         return (append, "###$$$***")
-    return (append, '"%s"' % actual_string)
+    return (append, '"%s"' % actual_string.decode('ascii'))
 
 
 def get_filter_arg_string_by_offset_no_skip(f, offset):
     """Extract string from given offset and ignore type byte."""
     f.seek(offset * 8)
     len = struct.unpack("<I", f.read(4))[0]-1
-    return '"%s"' % f.read(len)
+    return '"%s"' % f.read(len).decode('ascii')
 
 
 def get_filter_arg_network_address(f, offset):

--- a/reverse-sandbox/sandbox_regex.py
+++ b/reverse-sandbox/sandbox_regex.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 
+from os import path
 import logging
 import logging.config
 
-logging.config.fileConfig("logger.config")
+logging.config.fileConfig(path.join(path.dirname(__file__), "logger.config"))
 logger = logging.getLogger(__name__)
 
 class Node():

--- a/reverse-sandbox/sandbox_regex.py
+++ b/reverse-sandbox/sandbox_regex.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import logging
 import logging.config
@@ -491,7 +491,7 @@ def main():
             logger.info("total_re_length: 0x%x", re_length)
             re_debug_str = "re: [", ", ".join([hex(i) for i in re]), "]"
             logger.info(re_debug_str)
-            print parse_regex(re)
+            print(parse_regex(re))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
SandBlaster can now be imported to return the decompiled profile as a
dependency graph

Changes:
- Use absolute path for the logger config file
- Add get_graph_for_profile and process_profile_graph functions to
reverse_sandbox.py for returning the dependecy graph
- Add get_dependency_graph and get_paths functions to operation_node.py
that create the depenency graph.
- Decode strings as ASCII instead of bytes in sandbox_filter.py
- Remove a few unused variables