### PR TITLE
feat: Update reverse operations to Python3

### DIFF
--- a/reverse-sandbox/operation_node.py
+++ b/reverse-sandbox/operation_node.py
@@ -426,7 +426,7 @@ class OperationNode():
         return self.raw == other.raw
 
     def __hash__(self):
-        return struct.unpack('<I', ''.join([chr(v) for v in self.raw[:4]]))[0]
+        return struct.unpack('<I', b''.join([bytes([v]) for v in self.raw[:4]]))[0]
 
 
 # Operation nodes processed so far.

--- a/reverse-sandbox/regex_parser_v1.py
+++ b/reverse-sandbox/regex_parser_v1.py
@@ -111,11 +111,11 @@ node_type_dispatch_table = {
 
 def node_parse(re, i, regex_list, node_idx):
     node_type = struct.unpack('>I',
-        ''.join([chr(x) for x in re[i:i+4]]))[0]
+        b''.join([bytes([x]) for x in re[i:i+4]]))[0]
     node_transition = struct.unpack('>I',
-        ''.join([chr(x) for x in re[i+4:i+8]]))[0]
+        b''.join([bytes([x]) for x in re[i+4:i+8]]))[0]
     node_arg = struct.unpack('>I',
-        ''.join([chr(x) for x in re[i+8:i+12]]))[0]
+        b''.join([bytes([x]) for x in re[i+8:i+12]]))[0]
     i += 12
 
     logger.debug('node idx:{:#010x} type: {:#02x} arg: {:#010x}' \
@@ -136,10 +136,10 @@ def class_parse(re, i, classes, class_idx):
             return c
 
     class_size = struct.unpack('>I',
-        ''.join([chr(x) for x in re[i:i+4]]))[0]
+        b''.join([bytes([x]) for x in re[i:i+4]]))[0]
     i += 0x4
     content = struct.unpack('>{}I'.format(class_size),
-        ''.join([chr(x) for x in re[i:i+4*class_size]]))
+        b''.join([bytes([x]) for x in re[i:i+4*class_size]]))
     i += 0x4 * class_size
     assert(class_size % 2 == 0)
 
@@ -162,23 +162,23 @@ class RegexParser(object):
     @staticmethod
     def parse(re, i, regex_list):
         node_count = struct.unpack('>I',
-            ''.join([chr(x) for x in re[i:i+0x4]]))[0]
+            b''.join([bytes([x]) for x in re[i:i+0x4]]))[0]
         logger.debug('node count = {:#x}'.format(node_count))
 
         start_node = struct.unpack('>I',
-            ''.join([chr(x) for x in re[i+0x4:i+0x8]]))[0]
+            b''.join([bytes([x]) for x in re[i+0x4:i+0x8]]))[0]
         logger.debug('start node = {:#x}'.format(start_node))
 
         end_node = struct.unpack('>I',
-            ''.join([chr(x) for x in re[i+0x8:i+0xC]]))[0]
+            b''.join([bytes([x]) for x in re[i+0x8:i+0xC]]))[0]
         logger.debug('end node = {:#x}'.format(end_node))
 
         cclass_count = struct.unpack('>I',
-            ''.join([chr(x) for x in re[i+0xC:i+0x10]]))[0]
+            b''.join([bytes([x]) for x in re[i+0xC:i+0x10]]))[0]
         logger.debug('character class count = {:#x}'.format(cclass_count))
 
         submatch_count = struct.unpack('>I',
-            ''.join([chr(x) for x in re[i+0x10:i+0x14]]))[0]
+            b''.join([bytes([x]) for x in re[i+0x10:i+0x14]]))[0]
         i += 0x14
         logger.debug('submatch count = {:#x}'.format(submatch_count))
 

--- a/reverse-sandbox/regex_parser_v2.py
+++ b/reverse-sandbox/regex_parser_v2.py
@@ -112,13 +112,13 @@ node_type_dispatch_table = {
 
 def node_parse(re, i, regex_list, node_idx):
     node_type = struct.unpack('<B',
-        ''.join([chr(x) for x in re[i:i+1]]))[0]
+        b''.join([bytes([x]) for x in re[i:i+1]]))[0]
     node_transition = struct.unpack('<H',
-        ''.join([chr(x) for x in re[i+1:i+3]]))[0]
+        b''.join([bytes([x]) for x in re[i+1:i+3]]))[0]
     pad = struct.unpack('<B',
-        ''.join([chr(x) for x in re[i+3:i+4]]))[0]
+        b''.join([bytes([x]) for x in re[i+3:i+4]]))[0]
     node_arg = struct.unpack('<I',
-        ''.join([chr(x) for x in re[i+4:i+8]]))[0]
+        b''.join([bytes([x]) for x in re[i+4:i+8]]))[0]
     i += 8
 
     logger.debug('node idx:{:#06x} type: {:#02x} arg: {:#010x}' \
@@ -156,17 +156,17 @@ def classes_parse(re, i, cclass_count):
         return
 
     classes_magic, classes_size = struct.unpack('<II',
-        ''.join([chr(x) for x in re[i:i+8]]))
+        b''.join([bytes([x]) for x in re[i:i+8]]))
     i += 0x8
     logger.debug('classes magic = {:#x} size = {:#x}'.format(
         classes_magic, classes_size))
     assert(len(re) - i == classes_size)
     starts = struct.unpack('<{}I'.format(cclass_count),
-        ''.join([chr(x) for x in re[i:i+4*cclass_count]]))
+        b''.join([bytes([x]) for x in re[i:i+4*cclass_count]]))
     i += 0x4 * cclass_count
 
     lens = struct.unpack('<{}B'.format(cclass_count),
-        ''.join([chr(x) for x in re[i:i+cclass_count]]))
+        b''.join([bytes([x]) for x in re[i:i+cclass_count]]))
     i += cclass_count
 
     contents = [re[i+start:i+start+clen] for start, clen in zip(starts, lens)]
@@ -177,23 +177,23 @@ class RegexParser(object):
     @staticmethod
     def parse(re, i, regex_list):
         magic = struct.unpack('<I',
-            ''.join([chr(x) for x in re[i:i+0x4]]))[0]
+            b''.join([bytes([x]) for x in re[i:i+0x4]]))[0]
         logger.debug('magic = {:#x}'.format(magic))
 
         node_count = struct.unpack('<I',
-            ''.join([chr(x) for x in re[i+0x4:i+0x8]]))[0]
+            b''.join([bytes([x]) for x in re[i+0x4:i+0x8]]))[0]
         logger.debug('node count = {:#x}'.format(node_count))
 
         start_node = struct.unpack('<I',
-            ''.join([chr(x) for x in re[i+0x8:i+0xC]]))[0]
+            b''.join([bytes([x]) for x in re[i+0x8:i+0xC]]))[0]
         logger.debug('start node = {:#x}'.format(start_node))
 
         end_node = struct.unpack('<I',
-            ''.join([chr(x) for x in re[i+0xC:i+0x10]]))[0]
+            b''.join([bytes([x]) for x in re[i+0xC:i+0x10]]))[0]
         logger.debug('end node = {:#x}'.format(end_node))
 
         cclass_count = struct.unpack('<I',
-            ''.join([chr(x) for x in re[i+0x10:i+0x14]]))[0]
+            b''.join([bytes([x]) for x in re[i+0x10:i+0x14]]))[0]
         logger.debug('character class count = {:#x}'.format(cclass_count))
         i += 0x14
 

--- a/reverse-sandbox/regex_parser_v3.py
+++ b/reverse-sandbox/regex_parser_v3.py
@@ -146,7 +146,7 @@ class RegexParser(object):
 
     @staticmethod
     def parse(re, i, regex_list):
-        length = struct.unpack('<H', ''.join([chr(x) for x in re[i:i+2]]))[0]
+        length = struct.unpack('<H', b''.join([bytes([x]) for x in re[i:i+2]]))[0]
         logger.debug("re.length: 0x%x", length)
         i += 2
         assert(length == len(re)-i)

--- a/reverse-sandbox/sandbox_filter.py
+++ b/reverse-sandbox/sandbox_filter.py
@@ -37,7 +37,7 @@ def get_filter_arg_string_by_offset(f, offset):
     if ios_major_version >= 10:
         f.seek(offset * 8)
         s = f.read(4+len)
-        logger.info("binary string is " + s.encode("hex"))
+        logger.info("binary string is " + s.hex())
         ss = reverse_string.SandboxString()
         myss = ss.parse_byte_string(s[4:], global_vars)
         actual_string = ""
@@ -72,7 +72,7 @@ def get_filter_arg_string_by_offset_with_type(f, offset):
     if ios_major_version >= 10:
         f.seek(base_addr + offset * 8)
         s = f.read(4+len)
-        logger.info("binary string is " + s.encode("hex"))
+        logger.info("binary string is " + s.hex())
         ss = reverse_string.SandboxString()
         myss = ss.parse_byte_string(s[4:], global_vars)
         append = "literal"

--- a/reverse-sandbox/sandbox_regex.py
+++ b/reverse-sandbox/sandbox_regex.py
@@ -456,7 +456,7 @@ def create_regex_list(re):
 
     regex_list = []
 
-    version = struct.unpack('>I', ''.join([chr(x) for x in re[:4]]))[0]
+    version = struct.unpack('>I', b''.join([bytes(chr(x), 'utf-8') for x in re[:4]]))[0]
     logger.debug("re.version: 0x%x", version)
 
     i = 4


### PR DESCRIPTION
Up until now all reverse operations needed `Python2` to run. This lead to a user needing to have 2 different versions of Python installed on their system. Now, only `Python3` is required to run all `Sandblaster` operations.