### PR TITLE
Fix errors caused by running the script with python3

### DIFF
--- a/reverse-sandbox/reverse_sandbox.py
+++ b/reverse-sandbox/reverse_sandbox.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python2
 
 """
 iOS/OS X sandbox decompiler


### PR DESCRIPTION
`reverse_operations.py` still has some legacy `python2` code in it. For this reason it must be run using `python2`. This PR makes sense only with the current master version (14/07/2023), and if PR#17 will be merged before this PR this one can be discarded.